### PR TITLE
返却申請承認 の Mapper&Entity を作成

### DIFF
--- a/src/main/java/jp/ac/morijyobi/equipmentmanagementsystem/bean/entity/ReturnApproval.java
+++ b/src/main/java/jp/ac/morijyobi/equipmentmanagementsystem/bean/entity/ReturnApproval.java
@@ -1,0 +1,37 @@
+package jp.ac.morijyobi.equipmentmanagementsystem.bean.entity;
+
+import java.time.LocalDateTime;
+
+public class ReturnApproval {
+    private int id;
+    private final int returnApplicationId;
+    private final int accountId;
+    private final LocalDateTime createdAt;
+
+    public ReturnApproval(final int id, final int returnApplicationId, final int accountId, final LocalDateTime createdAt) {
+        this.id = id;
+        this.returnApplicationId = returnApplicationId;
+        this.accountId = accountId;
+        this.createdAt = createdAt;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public int getReturnApplicationId() {
+        return returnApplicationId;
+    }
+
+    public int getAccountId() {
+        return accountId;
+    }
+
+    public LocalDateTime getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setId(final int id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/jp/ac/morijyobi/equipmentmanagementsystem/mapper/IReturnApprovalMapper.java
+++ b/src/main/java/jp/ac/morijyobi/equipmentmanagementsystem/mapper/IReturnApprovalMapper.java
@@ -1,0 +1,14 @@
+package jp.ac.morijyobi.equipmentmanagementsystem.mapper;
+
+import jp.ac.morijyobi.equipmentmanagementsystem.bean.entity.ReturnApproval;
+import org.apache.ibatis.annotations.Insert;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Options;
+
+@Mapper
+public interface IReturnApprovalMapper {
+    @Insert("INSERT INTO return_approvals (return_application_id, account_id) " +
+            "VALUES (#{returnApplicationId}, #{accountId})")
+    @Options(useGeneratedKeys = true, keyProperty = "id")
+    public void insert(final ReturnApproval returnApproval);
+}


### PR DESCRIPTION
## 概要
<!-- 以下にissueを記載 (close #xxx)-->
close https://github.com/saito-kazumasa/equipment-management-system/issues/11

<!-- 以下にプルリクの内容を記載 -->
- 返却申請承認 の Mapper&Entity を作成

### スクリーンショット
<!-- 見て分かる変更の場合はスクリーンショットを添付する -->
特になし

### チェックリスト
<!-- 以下 項目を確認する -->
- [x] エラーが出ていない
- [ ] ~~動作確認を行い、正常に動作した~~ ※他データが必要なため動作確認は未実施
